### PR TITLE
feat(parser): add experimental MembershipEventType.Upgraded for tier-upgrade events

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,15 @@ The file is written as a valid JSON array, so it is directly parseable by tools/
 ## Current Schema Coverage Gaps
 
 - Creator goals are not mapped yet (awaiting enough stable raw samples).
-- Membership tier upgrades are not mapped yet (observed in the wild but shape is not confirmed).
+
+## Experimental / Unverified Features
+
+These features are implemented but not yet confirmed against a real InnerTube payload.
+They are marked `[Obsolete]` to emit a compiler warning at every call site.
+
+- **`MembershipEventType.Upgraded`** — tier-upgrade membership events detected when `headerSubtext`
+  starts with `"Upgraded membership to"`. Based on a single user report and synthesized payloads only.
+  See [#42](https://github.com/Agash/YTLiveChat/issues/42) for tracking and to contribute a real capture.
 
 ## Contributing
 

--- a/YTLiveChat.Example/ChatMonitorService.cs
+++ b/YTLiveChat.Example/ChatMonitorService.cs
@@ -840,6 +840,7 @@ internal class ChatMonitorService : IHostedService, IDisposable
 
     private static void WriteMembershipTag(MembershipDetails membership)
     {
+#pragma warning disable CS0618 // MembershipEventType.Upgraded is intentionally marked experimental
         string text = membership.EventType switch
         {
             MembershipEventType.New =>
@@ -851,6 +852,10 @@ internal class ChatMonitorService : IHostedService, IDisposable
             MembershipEventType.GiftPurchase =>
                 membership.GiftCount is int n ? $"GIFT x{n}" : "GIFT",
             MembershipEventType.GiftRedemption => "GIFTED",
+            MembershipEventType.Upgraded =>
+                membership.LevelName is string upgLvl && upgLvl != "Member"
+                    ? $"UPGRADE {upgLvl}"
+                    : "UPGRADE",
             _ => "MEM",
         };
 
@@ -860,8 +865,10 @@ internal class ChatMonitorService : IHostedService, IDisposable
             MembershipEventType.Milestone => ConsoleColor.Cyan,
             MembershipEventType.GiftPurchase => ConsoleColor.Magenta,
             MembershipEventType.GiftRedemption => ConsoleColor.Blue,
+            MembershipEventType.Upgraded => ConsoleColor.DarkGreen,
             _ => ConsoleColor.DarkGray,
         };
+#pragma warning restore CS0618
 
         WriteTag(text, color);
 
@@ -938,14 +945,17 @@ internal class ChatMonitorService : IHostedService, IDisposable
         }
 
         MembershipDetails membership = item.MembershipDetails;
+#pragma warning disable CS0618 // MembershipEventType.Upgraded is intentionally marked experimental
         return membership.EventType switch
         {
             MembershipEventType.New => membership.HeaderSubtext ?? membership.HeaderPrimaryText,
             MembershipEventType.Milestone => membership.HeaderPrimaryText ?? membership.HeaderSubtext,
             MembershipEventType.GiftPurchase => membership.HeaderPrimaryText,
             MembershipEventType.GiftRedemption => membership.HeaderPrimaryText,
+            MembershipEventType.Upgraded => membership.HeaderSubtext ?? membership.HeaderPrimaryText,
             _ => membership.HeaderPrimaryText ?? membership.HeaderSubtext,
         };
+#pragma warning restore CS0618
     }
 
     private sealed class MonitorSession

--- a/YTLiveChat.Tests/Helpers/ParserTests.cs
+++ b/YTLiveChat.Tests/Helpers/ParserTests.cs
@@ -391,6 +391,99 @@ public class ParserTests
         Assert.AreEqual("Welcome to Rat Boss!!", chatItem.MembershipDetails.HeaderSubtext);
     }
 
+    // ── Synthetic upgrade tests ────────────────────────────────────────────────
+    // IMPORTANT: These tests are based on a synthesized payload, not a real InnerTube capture.
+    // See https://github.com/Agash/YTLiveChat/issues/42 for the tracking issue.
+    // Replace with fixture-backed tests once a real upgrade event has been captured.
+
+    /// <summary>
+    /// Regression guard: the "Upgraded membership to" prefix must NOT trigger the New-member
+    /// detection path. The two prefixes ("Welcome to" vs "Upgraded membership to") are distinct
+    /// and the parser must route them to different event types.
+    /// SYNTHETIC — no real capture available yet (see https://github.com/Agash/YTLiveChat/issues/42).
+    /// </summary>
+    [TestMethod]
+    public void ToChatItem_SyntheticUpgrade_SimpleText_DoesNotClassifyAsNew()
+    {
+        string rendererContentJson = MembershipTestData.SyntheticUpgrade_SimpleText_RatBoss();
+        ChatItem? chatItem = ParseRendererContentToChatItem(
+            rendererContentJson,
+            "liveChatMembershipItemRenderer"
+        );
+
+        Assert.IsNotNull(chatItem);
+        Assert.IsNotNull(chatItem.MembershipDetails);
+        Assert.AreNotEqual(
+            MembershipEventType.New,
+            chatItem.MembershipDetails.EventType,
+            "An 'Upgraded membership to' payload must NOT be classified as New."
+        );
+        Assert.IsTrue(chatItem.IsMembership, "IsMembership should be true for upgrade events.");
+    }
+
+    /// <summary>
+    /// Happy path: simpleText shape "Upgraded membership to Rat Boss!!" is classified as
+    /// Upgraded and the tier name "Rat Boss!" (with its trailing "!") is extracted correctly.
+    /// SYNTHETIC — no real capture available yet (see https://github.com/Agash/YTLiveChat/issues/42).
+    /// </summary>
+    [TestMethod]
+#pragma warning disable CS0618 // MembershipEventType.Upgraded is intentionally marked experimental
+    public void ToChatItem_SyntheticUpgrade_SimpleText_ParsesUpgradedEventAndTierName()
+    {
+        string rendererContentJson = MembershipTestData.SyntheticUpgrade_SimpleText_RatBoss();
+        ChatItem? chatItem = ParseRendererContentToChatItem(
+            rendererContentJson,
+            "liveChatMembershipItemRenderer"
+        );
+
+        Assert.IsNotNull(chatItem);
+        Assert.IsNotNull(chatItem.MembershipDetails);
+        Assert.AreEqual(
+            MembershipEventType.Upgraded,
+            chatItem.MembershipDetails.EventType,
+            "EventType should be Upgraded for 'Upgraded membership to' headerSubtext."
+        );
+        Assert.AreEqual(
+            "Rat Boss!",
+            chatItem.MembershipDetails.LevelName,
+            "Tier name extracted via regex must preserve the trailing '!' from the tier name itself."
+        );
+        Assert.AreEqual("Upgraded membership to Rat Boss!!", chatItem.MembershipDetails.HeaderSubtext);
+        Assert.IsTrue(chatItem.IsMembership);
+    }
+#pragma warning restore CS0618
+
+    /// <summary>
+    /// Happy path: runs shape ["Upgraded membership to ", "Rat Boss!", "!"] is classified as
+    /// Upgraded and the tier name is extracted from the second run (same mechanism as New-member runs).
+    /// SYNTHETIC — no real capture available yet (see https://github.com/Agash/YTLiveChat/issues/42).
+    /// </summary>
+    [TestMethod]
+#pragma warning disable CS0618 // MembershipEventType.Upgraded is intentionally marked experimental
+    public void ToChatItem_SyntheticUpgrade_RunsShape_ParsesUpgradedEventAndTierName()
+    {
+        string rendererContentJson = MembershipTestData.SyntheticUpgrade_RunsShape_RatBoss();
+        ChatItem? chatItem = ParseRendererContentToChatItem(
+            rendererContentJson,
+            "liveChatMembershipItemRenderer"
+        );
+
+        Assert.IsNotNull(chatItem);
+        Assert.IsNotNull(chatItem.MembershipDetails);
+        Assert.AreEqual(
+            MembershipEventType.Upgraded,
+            chatItem.MembershipDetails.EventType,
+            "EventType should be Upgraded for runs-shaped 'Upgraded membership to' headerSubtext."
+        );
+        Assert.AreEqual(
+            "Rat Boss!",
+            chatItem.MembershipDetails.LevelName,
+            "Tier name extracted via TryExtractTierNameFromHeaderSubtextRuns must preserve trailing '!'."
+        );
+        Assert.IsTrue(chatItem.IsMembership);
+    }
+#pragma warning restore CS0618
+
     [TestMethod]
     public void ToChatItem_NewMemberFromLatestLog_WithNewMemberBadge_ParsesCorrectly()
     {

--- a/YTLiveChat.Tests/TestData/MembershipTestData.cs
+++ b/YTLiveChat.Tests/TestData/MembershipTestData.cs
@@ -323,6 +323,68 @@ internal static class MembershipTestData
             }
             """;
     }
+    // ── Synthetic upgrade test data ─────────────────────────────────────────────
+    // NOTE: No real InnerTube capture for tier-upgrade events exists yet.
+    // These fixtures are synthesized from the user report in https://github.com/Agash/YTLiveChat/issues/42
+    // (tier name "Rat Boss!", observed headerSubtext "Upgraded membership to Rat Boss!!") and from
+    // the analogous shape of existing New-member fixtures.  Replace with real captures when available.
+
+    /// <summary>
+    /// SYNTHETIC — simpleText shape: "Upgraded membership to Rat Boss!!" (tier name ends with "!").
+    /// Mirrors the simpleText new-member fixture (<see cref="NewMemberWithExclamationTier_RatBoss"/>).
+    /// </summary>
+    public static string SyntheticUpgrade_SimpleText_RatBoss()
+    {
+        long ts = GetTimestampUsec(131);
+        return $$"""
+            {
+              "id": "UPGRADE_SYNTHETIC_SIMPLE_ID",
+              "timestampUsec": "{{ts}}",
+              "authorExternalChannelId": "UC_CHANNEL_ID_UPGRADE_SIMPLE",
+              "headerSubtext": { "simpleText": "Upgraded membership to Rat Boss!!" },
+              "authorName": { "simpleText": "UpgradeUserSimple" },
+              "authorPhoto": { "thumbnails": [{ "url": "https://yt4.ggpht.com/placeholder_upgrade_s32.png" }] },
+              "authorBadges": [{
+                "liveChatAuthorBadgeRenderer": {
+                  "customThumbnail": { "thumbnails": [{ "url": "https://yt3.ggpht.com/placeholder_upgrade_badge_s16.png" }] },
+                  "tooltip": "Member (1 month)",
+                  "accessibility": { "accessibilityData": { "label": "Member (1 month)" } }
+                }
+              }]
+            }
+            """;
+    }
+
+    /// <summary>
+    /// SYNTHETIC — runs shape: ["Upgraded membership to ", "Rat Boss!", "!"] (tier name ends with "!").
+    /// Mirrors the runs new-member fixture (<see cref="NewMemberChickenMcNugget"/>).
+    /// </summary>
+    public static string SyntheticUpgrade_RunsShape_RatBoss()
+    {
+        long ts = GetTimestampUsec(132);
+        return $$"""
+            {
+              "id": "UPGRADE_SYNTHETIC_RUNS_ID",
+              "timestampUsec": "{{ts}}",
+              "authorExternalChannelId": "UC_CHANNEL_ID_UPGRADE_RUNS",
+              "headerSubtext": { "runs": [
+                { "text": "Upgraded membership to " },
+                { "text": "Rat Boss!" },
+                { "text": "!" }
+              ]},
+              "authorName": { "simpleText": "UpgradeUserRuns" },
+              "authorPhoto": { "thumbnails": [{ "url": "https://yt4.ggpht.com/placeholder_upgrade_runs_s32.png" }] },
+              "authorBadges": [{
+                "liveChatAuthorBadgeRenderer": {
+                  "customThumbnail": { "thumbnails": [{ "url": "https://yt3.ggpht.com/placeholder_upgrade_runs_badge_s16.png" }] },
+                  "tooltip": "Member (1 month)",
+                  "accessibility": { "accessibilityData": { "label": "Member (1 month)" } }
+                }
+              }]
+            }
+            """;
+    }
+
     public static string NewMemberWithExclamationTier_RatBoss()
     {
         long ts = GetTimestampUsec(130); // Unique offset

--- a/YTLiveChat/Contracts/Models/MembershipDetails.cs
+++ b/YTLiveChat/Contracts/Models/MembershipDetails.cs
@@ -31,6 +31,23 @@ public enum MembershipEventType
     /// The author of the ChatItem is the recipient.
     /// </summary>
     GiftRedemption,
+
+    /// <summary>
+    /// A user upgraded their existing membership to a higher tier.
+    /// Detected from <c>headerSubtext</c> starting with "Upgraded membership to".
+    /// <para>
+    /// <b>EXPERIMENTAL / UNVERIFIED:</b> This event type is based on a single user report
+    /// (Agash/YTLiveChat#42) and a synthesized payload. No raw InnerTube capture has been
+    /// confirmed yet. The shape (simpleText vs. runs, exact prefix wording) may differ from
+    /// what is implemented here. Treat <c>LevelName</c> with caution for this event type.
+    /// </para>
+    /// </summary>
+    [Obsolete(
+        "EXPERIMENTAL: MembershipEventType.Upgraded is unverified against a real InnerTube payload. "
+        + "The detection heuristic and tier-name extraction may be incorrect. "
+        + "See https://github.com/Agash/YTLiveChat/issues/42 for tracking."
+    )]
+    Upgraded,
 }
 
 /// <summary>

--- a/YTLiveChat/Helpers/Parser.cs
+++ b/YTLiveChat/Helpers/Parser.cs
@@ -1064,6 +1064,39 @@ internal static partial class Parser
                     }
                 }
                 else if (
+                    membershipInfo.HeaderSubtext?.StartsWith(
+                        "Upgraded membership to",
+                        StringComparison.OrdinalIgnoreCase
+                    ) == true
+                )
+                {
+                    // EXPERIMENTAL: shape is based on a single user report and a synthesized payload.
+                    // See https://github.com/Agash/YTLiveChat/issues/42 for tracking.
+#pragma warning disable CS0618 // MembershipEventType.Upgraded is intentionally marked experimental
+                    membershipInfo.EventType = Contracts.Models.MembershipEventType.Upgraded;
+#pragma warning restore CS0618
+
+                    // Try runs first (e.g. ["Upgraded membership to ", "Rat Boss!", "!"])
+                    string? tierFromRuns = TryExtractTierNameFromHeaderSubtextRuns(
+                        membershipItem.HeaderSubtext?.Runs
+                    );
+                    if (!string.IsNullOrWhiteSpace(tierFromRuns))
+                    {
+                        membershipInfo.LevelName = tierFromRuns!;
+                    }
+                    else if (!string.IsNullOrEmpty(membershipInfo.HeaderSubtext))
+                    {
+                        // Regex fallback for simpleText shape: "Upgraded membership to {TierName}!"
+                        // The greedy .+ correctly captures tier names that themselves end with "!" (e.g. "Rat Boss!").
+                        Match upgradeMatch = UpgradedMemberLevelFromSubtextRegex()
+                            .Match(membershipInfo.HeaderSubtext);
+                        if (upgradeMatch.Success)
+                        {
+                            membershipInfo.LevelName = upgradeMatch.Groups[1].Value.Trim();
+                        }
+                    }
+                }
+                else if (
                     membershipInfo.HeaderPrimaryText?.IndexOf(
                         "member for",
                         StringComparison.OrdinalIgnoreCase
@@ -1827,6 +1860,10 @@ internal static partial class Parser
     [GeneratedRegex(@"^Welcome to (.+)!$", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
     private static partial Regex NewMemberLevelFromSubtextRegex();
 
+    // EXPERIMENTAL — see MembershipEventType.Upgraded and https://github.com/Agash/YTLiveChat/issues/42
+    [GeneratedRegex(@"^Upgraded membership to (.+)!$", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
+    private static partial Regex UpgradedMemberLevelFromSubtextRegex();
+
     // Regex to extract gifter name from redemption message like "GifterName gifted you..."
     [GeneratedRegex(@"^(.*?) gifted you", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
     private static partial Regex GiftRedemptionGifterRegex();
@@ -1985,6 +2022,14 @@ internal static partial class Parser
     );
 
     private static Regex NewMemberLevelFromSubtextRegex() => _newMemberLevelFromSubtextRegex;
+
+    // EXPERIMENTAL — see MembershipEventType.Upgraded and https://github.com/Agash/YTLiveChat/issues/42
+    private static readonly Regex _upgradedMemberLevelFromSubtextRegex = new(
+        @"^Upgraded membership to (.+)!$",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled
+    );
+
+    private static Regex UpgradedMemberLevelFromSubtextRegex() => _upgradedMemberLevelFromSubtextRegex;
 
     private static readonly Regex _giftRedemptionGifterRegex = new(
         @"^(.*?) gifted you",


### PR DESCRIPTION
Closes #42

- Adds `MembershipEventType.Upgraded` (marked `[Obsolete]` emits warning at every call site to signal experimental status, Experimental is unavailable in netstandard and I won't add a polyfill for something temporary)
- Parser detects tier-upgrade events when `headerSubtext` starts with `"Upgraded membership to"`, using the same runs-first + regex-fallback tier extraction already proven for `New` events
- Example project renders upgrade events as `[UPGRADE {Tier}]` in dark green
- README gains an **Experimental / Unverified Features** section

## Status

**EXPERIMENTAL, as in unverified against a real JSON payload.**

This is based entirely on a single user report from @WolfwithSword (#42) and synthesized payloads. The observed `headerSubtext` was `"Upgraded membership to Rat Boss!!"` (tier name `"Rat Boss!"` confirmed by the reporter, but from non-library output, not a captured InnerTube response).

Unknowns that still need a real capture to confirm:
- Whether the renderer key is always `liveChatMembershipItemRenderer` (assumed yes)
- Whether `headerSubtext` is simpleText or runs in practice
- Whether the exact prefix `"Upgraded membership to"` is stable

## Test plan

- [ ] Three synthetic tests pass on net8.0 and net10.0:
  - `ToChatItem_SyntheticUpgrade_SimpleText_DoesNotClassifyAsNew` regression guard: upgrade shape must NOT route to `New`
  - `ToChatItem_SyntheticUpgrade_SimpleText_ParsesUpgradedEventAndTierName` simpleText shape → `Upgraded`, `LevelName = "Rat Boss!"`
  - `ToChatItem_SyntheticUpgrade_RunsShape_ParsesUpgradedEventAndTierName` runs shape → `Upgraded`, tier from second run
- [ ] All existing tests still pass (no regression)
- [ ] **Real capture needed**: if you have a channel with multiple membership tiers, trigger an upgrade and capture via `dotnet run --project YTLiveChat.Tools -- watch @handle` or the debug JSON log. Share the raw `liveChatMembershipItemRenderer` payload in #42 to verify/correct this implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code), checked, extended, corrected and verified by me :) 