### PR TITLE
feat(parser): add experimental MembershipEventType.Upgraded for tier-upgrade events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,10 @@
   `LiveChatViewerEngagementMessageRenderer` record, enabling proper `Bold`/`Italics`/`IsDeemphasized`
   pass-through for poll result and other engagement messages.
 
-### Added (experimental — unverified)
-- `MembershipEventType.Upgraded` — new enum value for tier-upgrade membership events, detected when
-  `headerSubtext` starts with `"Upgraded membership to"`. Tier name is extracted via the same
-  runs-first / regex-fallback approach used for `New` events.
-  **EXPERIMENTAL:** Based on a single user report (#42) and synthesized payloads only; no raw
-  InnerTube capture has been confirmed. The enum value is marked `[Obsolete]` to emit a compiler
-  warning at every call site. The heuristic and tier-name extraction may be incorrect.
-  See [#42](https://github.com/Agash/YTLiveChat/issues/42) for tracking.
+### Added
+- `MembershipEventType.Upgraded` — tier-upgrade membership events; detected when `headerSubtext`
+  uses the runs shape `["Upgraded membership to ", "{TierName}", "!"]`. Tier name is extracted from
+  the second run (same mechanism as `New` events). Confirmed against a real InnerTube capture.
 
 ### Added (recent)
 - `Author.ChannelHandle` — the author's `@handle`, populated for ticker bar items where YouTube includes it directly in the outer ticker renderer (`liveChatTickerPaidMessageItemRenderer.authorUsername`). Parser also falls back to `authorPhoto.accessibility.accessibilityData.label` which carries the same value on all observed ticker paid-message items.

--- a/README.md
+++ b/README.md
@@ -202,7 +202,15 @@ The file is written as a valid JSON array, so it is directly parseable by tools/
 ## Current Schema Coverage Gaps
 
 - Creator goals are not mapped yet (awaiting enough stable raw samples).
-- Membership tier upgrades are not mapped yet (observed in the wild but shape is not confirmed).
+
+## Experimental / Unverified Features
+
+These features are implemented but not yet confirmed against a real InnerTube payload.
+They are marked `[Obsolete]` to emit a compiler warning at every call site.
+
+- **`MembershipEventType.Upgraded`** — tier-upgrade membership events detected when `headerSubtext`
+  starts with `"Upgraded membership to"`. Based on a single user report and synthesized payloads only.
+  See [#42](https://github.com/Agash/YTLiveChat/issues/42) for tracking and to contribute a real capture.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ dotnet add package Agash.YTLiveChat.DependencyInjection
 **Chat messages**
 - Chat messages (`ChatReceived`) — text, emoji, images
 - Super Chats / Super Stickers with parsed amount + currency
-- Membership events — new join, milestone, gift purchase, gift redemption (`MembershipDetails.EventType`)
+- Membership events — new join, milestone, gift purchase, gift redemption, tier upgrade (`MembershipDetails.EventType`)
 - Ticker support (`addLiveChatTickerItemAction`) — paid messages, membership items, gift purchase announcements; ticker items include author channel ID, author thumbnail, and `Author.ChannelHandle` (the `@handle`) when available
 - Viewer leaderboard rank extraction via `ChatItem.ViewerLeaderboardRank` (YouTube points crown tags like `#1`)
 
@@ -202,15 +202,6 @@ The file is written as a valid JSON array, so it is directly parseable by tools/
 ## Current Schema Coverage Gaps
 
 - Creator goals are not mapped yet (awaiting enough stable raw samples).
-
-## Experimental / Unverified Features
-
-These features are implemented but not yet confirmed against a real InnerTube payload.
-They are marked `[Obsolete]` to emit a compiler warning at every call site.
-
-- **`MembershipEventType.Upgraded`** — tier-upgrade membership events detected when `headerSubtext`
-  starts with `"Upgraded membership to"`. Based on a single user report and synthesized payloads only.
-  See [#42](https://github.com/Agash/YTLiveChat/issues/42) for tracking and to contribute a real capture.
 
 ## Contributing
 

--- a/YTLiveChat.DependencyInjection/YTLiveChat.DependencyInjection.csproj
+++ b/YTLiveChat.DependencyInjection/YTLiveChat.DependencyInjection.csproj
@@ -31,12 +31,12 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.6" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\LICENSE.txt" Pack="true" PackagePath="" />

--- a/YTLiveChat.Example/ChatMonitorService.cs
+++ b/YTLiveChat.Example/ChatMonitorService.cs
@@ -861,6 +861,7 @@ internal class ChatMonitorService : IHostedService, IDisposable
 
     private static void WriteMembershipTag(MembershipDetails membership)
     {
+#pragma warning disable CS0618 // MembershipEventType.Upgraded is intentionally marked experimental
         string text = membership.EventType switch
         {
             MembershipEventType.New =>
@@ -872,6 +873,10 @@ internal class ChatMonitorService : IHostedService, IDisposable
             MembershipEventType.GiftPurchase =>
                 membership.GiftCount is int n ? $"GIFT x{n}" : "GIFT",
             MembershipEventType.GiftRedemption => "GIFTED",
+            MembershipEventType.Upgraded =>
+                membership.LevelName is string upgLvl && upgLvl != "Member"
+                    ? $"UPGRADE {upgLvl}"
+                    : "UPGRADE",
             _ => "MEM",
         };
 
@@ -881,8 +886,10 @@ internal class ChatMonitorService : IHostedService, IDisposable
             MembershipEventType.Milestone => ConsoleColor.Cyan,
             MembershipEventType.GiftPurchase => ConsoleColor.Magenta,
             MembershipEventType.GiftRedemption => ConsoleColor.Blue,
+            MembershipEventType.Upgraded => ConsoleColor.DarkGreen,
             _ => ConsoleColor.DarkGray,
         };
+#pragma warning restore CS0618
 
         WriteTag(text, color);
 
@@ -959,14 +966,17 @@ internal class ChatMonitorService : IHostedService, IDisposable
         }
 
         MembershipDetails membership = item.MembershipDetails;
+#pragma warning disable CS0618 // MembershipEventType.Upgraded is intentionally marked experimental
         return membership.EventType switch
         {
             MembershipEventType.New => membership.HeaderSubtext ?? membership.HeaderPrimaryText,
             MembershipEventType.Milestone => membership.HeaderPrimaryText ?? membership.HeaderSubtext,
             MembershipEventType.GiftPurchase => membership.HeaderPrimaryText,
             MembershipEventType.GiftRedemption => membership.HeaderPrimaryText,
+            MembershipEventType.Upgraded => membership.HeaderSubtext ?? membership.HeaderPrimaryText,
             _ => membership.HeaderPrimaryText ?? membership.HeaderSubtext,
         };
+#pragma warning restore CS0618
     }
 
     private sealed class MonitorSession

--- a/YTLiveChat.Example/ChatMonitorService.cs
+++ b/YTLiveChat.Example/ChatMonitorService.cs
@@ -861,7 +861,6 @@ internal class ChatMonitorService : IHostedService, IDisposable
 
     private static void WriteMembershipTag(MembershipDetails membership)
     {
-#pragma warning disable CS0618 // MembershipEventType.Upgraded is intentionally marked experimental
         string text = membership.EventType switch
         {
             MembershipEventType.New =>
@@ -889,7 +888,6 @@ internal class ChatMonitorService : IHostedService, IDisposable
             MembershipEventType.Upgraded => ConsoleColor.DarkGreen,
             _ => ConsoleColor.DarkGray,
         };
-#pragma warning restore CS0618
 
         WriteTag(text, color);
 
@@ -966,7 +964,6 @@ internal class ChatMonitorService : IHostedService, IDisposable
         }
 
         MembershipDetails membership = item.MembershipDetails;
-#pragma warning disable CS0618 // MembershipEventType.Upgraded is intentionally marked experimental
         return membership.EventType switch
         {
             MembershipEventType.New => membership.HeaderSubtext ?? membership.HeaderPrimaryText,
@@ -976,7 +973,6 @@ internal class ChatMonitorService : IHostedService, IDisposable
             MembershipEventType.Upgraded => membership.HeaderSubtext ?? membership.HeaderPrimaryText,
             _ => membership.HeaderPrimaryText ?? membership.HeaderSubtext,
         };
-#pragma warning restore CS0618
     }
 
     private sealed class MonitorSession

--- a/YTLiveChat.Example/YTLiveChat.Example.csproj
+++ b/YTLiveChat.Example/YTLiveChat.Example.csproj
@@ -3,8 +3,8 @@
     <ProjectReference Include="..\YTLiveChat.DependencyInjection\YTLiveChat.DependencyInjection.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.6" />
   </ItemGroup>
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/YTLiveChat.Tests/Helpers/ParserTests.cs
+++ b/YTLiveChat.Tests/Helpers/ParserTests.cs
@@ -391,6 +391,99 @@ public class ParserTests
         Assert.AreEqual("Welcome to Rat Boss!!", chatItem.MembershipDetails.HeaderSubtext);
     }
 
+    // ── Synthetic upgrade tests ────────────────────────────────────────────────
+    // IMPORTANT: These tests are based on a synthesized payload, not a real InnerTube capture.
+    // See https://github.com/Agash/YTLiveChat/issues/42 for the tracking issue.
+    // Replace with fixture-backed tests once a real upgrade event has been captured.
+
+    /// <summary>
+    /// Regression guard: the "Upgraded membership to" prefix must NOT trigger the New-member
+    /// detection path. The two prefixes ("Welcome to" vs "Upgraded membership to") are distinct
+    /// and the parser must route them to different event types.
+    /// SYNTHETIC — no real capture available yet (see https://github.com/Agash/YTLiveChat/issues/42).
+    /// </summary>
+    [TestMethod]
+    public void ToChatItem_SyntheticUpgrade_SimpleText_DoesNotClassifyAsNew()
+    {
+        string rendererContentJson = MembershipTestData.SyntheticUpgrade_SimpleText_RatBoss();
+        ChatItem? chatItem = ParseRendererContentToChatItem(
+            rendererContentJson,
+            "liveChatMembershipItemRenderer"
+        );
+
+        Assert.IsNotNull(chatItem);
+        Assert.IsNotNull(chatItem.MembershipDetails);
+        Assert.AreNotEqual(
+            MembershipEventType.New,
+            chatItem.MembershipDetails.EventType,
+            "An 'Upgraded membership to' payload must NOT be classified as New."
+        );
+        Assert.IsTrue(chatItem.IsMembership, "IsMembership should be true for upgrade events.");
+    }
+
+    /// <summary>
+    /// Happy path: simpleText shape "Upgraded membership to Rat Boss!!" is classified as
+    /// Upgraded and the tier name "Rat Boss!" (with its trailing "!") is extracted correctly.
+    /// SYNTHETIC — no real capture available yet (see https://github.com/Agash/YTLiveChat/issues/42).
+    /// </summary>
+    [TestMethod]
+#pragma warning disable CS0618 // MembershipEventType.Upgraded is intentionally marked experimental
+    public void ToChatItem_SyntheticUpgrade_SimpleText_ParsesUpgradedEventAndTierName()
+    {
+        string rendererContentJson = MembershipTestData.SyntheticUpgrade_SimpleText_RatBoss();
+        ChatItem? chatItem = ParseRendererContentToChatItem(
+            rendererContentJson,
+            "liveChatMembershipItemRenderer"
+        );
+
+        Assert.IsNotNull(chatItem);
+        Assert.IsNotNull(chatItem.MembershipDetails);
+        Assert.AreEqual(
+            MembershipEventType.Upgraded,
+            chatItem.MembershipDetails.EventType,
+            "EventType should be Upgraded for 'Upgraded membership to' headerSubtext."
+        );
+        Assert.AreEqual(
+            "Rat Boss!",
+            chatItem.MembershipDetails.LevelName,
+            "Tier name extracted via regex must preserve the trailing '!' from the tier name itself."
+        );
+        Assert.AreEqual("Upgraded membership to Rat Boss!!", chatItem.MembershipDetails.HeaderSubtext);
+        Assert.IsTrue(chatItem.IsMembership);
+    }
+#pragma warning restore CS0618
+
+    /// <summary>
+    /// Happy path: runs shape ["Upgraded membership to ", "Rat Boss!", "!"] is classified as
+    /// Upgraded and the tier name is extracted from the second run (same mechanism as New-member runs).
+    /// SYNTHETIC — no real capture available yet (see https://github.com/Agash/YTLiveChat/issues/42).
+    /// </summary>
+    [TestMethod]
+#pragma warning disable CS0618 // MembershipEventType.Upgraded is intentionally marked experimental
+    public void ToChatItem_SyntheticUpgrade_RunsShape_ParsesUpgradedEventAndTierName()
+    {
+        string rendererContentJson = MembershipTestData.SyntheticUpgrade_RunsShape_RatBoss();
+        ChatItem? chatItem = ParseRendererContentToChatItem(
+            rendererContentJson,
+            "liveChatMembershipItemRenderer"
+        );
+
+        Assert.IsNotNull(chatItem);
+        Assert.IsNotNull(chatItem.MembershipDetails);
+        Assert.AreEqual(
+            MembershipEventType.Upgraded,
+            chatItem.MembershipDetails.EventType,
+            "EventType should be Upgraded for runs-shaped 'Upgraded membership to' headerSubtext."
+        );
+        Assert.AreEqual(
+            "Rat Boss!",
+            chatItem.MembershipDetails.LevelName,
+            "Tier name extracted via TryExtractTierNameFromHeaderSubtextRuns must preserve trailing '!'."
+        );
+        Assert.IsTrue(chatItem.IsMembership);
+    }
+#pragma warning restore CS0618
+
     [TestMethod]
     public void ToChatItem_NewMemberFromLatestLog_WithNewMemberBadge_ParsesCorrectly()
     {

--- a/YTLiveChat.Tests/Helpers/ParserTests.cs
+++ b/YTLiveChat.Tests/Helpers/ParserTests.cs
@@ -391,21 +391,18 @@ public class ParserTests
         Assert.AreEqual("Welcome to Rat Boss!!", chatItem.MembershipDetails.HeaderSubtext);
     }
 
-    // ── Synthetic upgrade tests ────────────────────────────────────────────────
-    // IMPORTANT: These tests are based on a synthesized payload, not a real InnerTube capture.
+    // ── Tier-upgrade tests (real InnerTube capture) ────────────────────────────
+    // Real event captured 2026-04-15: @rembray upgraded to "Cardinal Archer".
     // See https://github.com/Agash/YTLiveChat/issues/42 for the tracking issue.
-    // Replace with fixture-backed tests once a real upgrade event has been captured.
 
     /// <summary>
     /// Regression guard: the "Upgraded membership to" prefix must NOT trigger the New-member
-    /// detection path. The two prefixes ("Welcome to" vs "Upgraded membership to") are distinct
-    /// and the parser must route them to different event types.
-    /// SYNTHETIC — no real capture available yet (see https://github.com/Agash/YTLiveChat/issues/42).
+    /// detection path. Verified with a real InnerTube capture.
     /// </summary>
     [TestMethod]
-    public void ToChatItem_SyntheticUpgrade_SimpleText_DoesNotClassifyAsNew()
+    public void ToChatItem_RealUpgrade_CardinalArcher_DoesNotClassifyAsNew()
     {
-        string rendererContentJson = MembershipTestData.SyntheticUpgrade_SimpleText_RatBoss();
+        string rendererContentJson = MembershipTestData.RealUpgrade_Runs_CardinalArcher();
         ChatItem? chatItem = ParseRendererContentToChatItem(
             rendererContentJson,
             "liveChatMembershipItemRenderer"
@@ -422,15 +419,13 @@ public class ParserTests
     }
 
     /// <summary>
-    /// Happy path: simpleText shape "Upgraded membership to Rat Boss!!" is classified as
-    /// Upgraded and the tier name "Rat Boss!" (with its trailing "!") is extracted correctly.
-    /// SYNTHETIC — no real capture available yet (see https://github.com/Agash/YTLiveChat/issues/42).
+    /// Happy path: real capture of runs shape ["Upgraded membership to ", "Cardinal Archer", "!"]
+    /// is classified as Upgraded and tier name "Cardinal Archer" is extracted from the second run.
     /// </summary>
     [TestMethod]
-#pragma warning disable CS0618 // MembershipEventType.Upgraded is intentionally marked experimental
-    public void ToChatItem_SyntheticUpgrade_SimpleText_ParsesUpgradedEventAndTierName()
+    public void ToChatItem_RealUpgrade_CardinalArcher_ParsesUpgradedEventAndTierName()
     {
-        string rendererContentJson = MembershipTestData.SyntheticUpgrade_SimpleText_RatBoss();
+        string rendererContentJson = MembershipTestData.RealUpgrade_Runs_CardinalArcher();
         ChatItem? chatItem = ParseRendererContentToChatItem(
             rendererContentJson,
             "liveChatMembershipItemRenderer"
@@ -444,45 +439,15 @@ public class ParserTests
             "EventType should be Upgraded for 'Upgraded membership to' headerSubtext."
         );
         Assert.AreEqual(
-            "Rat Boss!",
+            "Cardinal Archer",
             chatItem.MembershipDetails.LevelName,
-            "Tier name extracted via regex must preserve the trailing '!' from the tier name itself."
+            "Tier name should be extracted from the second run."
         );
-        Assert.AreEqual("Upgraded membership to Rat Boss!!", chatItem.MembershipDetails.HeaderSubtext);
+        Assert.AreEqual("Upgraded membership to Cardinal Archer!", chatItem.MembershipDetails.HeaderSubtext);
+        Assert.AreEqual("@rembray", chatItem.Author.Name);
+        Assert.AreEqual("UCdtey2zoNQ9HVgdK9oEA_RA", chatItem.Author.ChannelId);
         Assert.IsTrue(chatItem.IsMembership);
     }
-#pragma warning restore CS0618
-
-    /// <summary>
-    /// Happy path: runs shape ["Upgraded membership to ", "Rat Boss!", "!"] is classified as
-    /// Upgraded and the tier name is extracted from the second run (same mechanism as New-member runs).
-    /// SYNTHETIC — no real capture available yet (see https://github.com/Agash/YTLiveChat/issues/42).
-    /// </summary>
-    [TestMethod]
-#pragma warning disable CS0618 // MembershipEventType.Upgraded is intentionally marked experimental
-    public void ToChatItem_SyntheticUpgrade_RunsShape_ParsesUpgradedEventAndTierName()
-    {
-        string rendererContentJson = MembershipTestData.SyntheticUpgrade_RunsShape_RatBoss();
-        ChatItem? chatItem = ParseRendererContentToChatItem(
-            rendererContentJson,
-            "liveChatMembershipItemRenderer"
-        );
-
-        Assert.IsNotNull(chatItem);
-        Assert.IsNotNull(chatItem.MembershipDetails);
-        Assert.AreEqual(
-            MembershipEventType.Upgraded,
-            chatItem.MembershipDetails.EventType,
-            "EventType should be Upgraded for runs-shaped 'Upgraded membership to' headerSubtext."
-        );
-        Assert.AreEqual(
-            "Rat Boss!",
-            chatItem.MembershipDetails.LevelName,
-            "Tier name extracted via TryExtractTierNameFromHeaderSubtextRuns must preserve trailing '!'."
-        );
-        Assert.IsTrue(chatItem.IsMembership);
-    }
-#pragma warning restore CS0618
 
     [TestMethod]
     public void ToChatItem_NewMemberFromLatestLog_WithNewMemberBadge_ParsesCorrectly()

--- a/YTLiveChat.Tests/TestData/MembershipTestData.cs
+++ b/YTLiveChat.Tests/TestData/MembershipTestData.cs
@@ -323,6 +323,68 @@ internal static class MembershipTestData
             }
             """;
     }
+    // ── Synthetic upgrade test data ─────────────────────────────────────────────
+    // NOTE: No real InnerTube capture for tier-upgrade events exists yet.
+    // These fixtures are synthesized from the user report in https://github.com/Agash/YTLiveChat/issues/42
+    // (tier name "Rat Boss!", observed headerSubtext "Upgraded membership to Rat Boss!!") and from
+    // the analogous shape of existing New-member fixtures.  Replace with real captures when available.
+
+    /// <summary>
+    /// SYNTHETIC — simpleText shape: "Upgraded membership to Rat Boss!!" (tier name ends with "!").
+    /// Mirrors the simpleText new-member fixture (<see cref="NewMemberWithExclamationTier_RatBoss"/>).
+    /// </summary>
+    public static string SyntheticUpgrade_SimpleText_RatBoss()
+    {
+        long ts = GetTimestampUsec(131);
+        return $$"""
+            {
+              "id": "UPGRADE_SYNTHETIC_SIMPLE_ID",
+              "timestampUsec": "{{ts}}",
+              "authorExternalChannelId": "UC_CHANNEL_ID_UPGRADE_SIMPLE",
+              "headerSubtext": { "simpleText": "Upgraded membership to Rat Boss!!" },
+              "authorName": { "simpleText": "UpgradeUserSimple" },
+              "authorPhoto": { "thumbnails": [{ "url": "https://yt4.ggpht.com/placeholder_upgrade_s32.png" }] },
+              "authorBadges": [{
+                "liveChatAuthorBadgeRenderer": {
+                  "customThumbnail": { "thumbnails": [{ "url": "https://yt3.ggpht.com/placeholder_upgrade_badge_s16.png" }] },
+                  "tooltip": "Member (1 month)",
+                  "accessibility": { "accessibilityData": { "label": "Member (1 month)" } }
+                }
+              }]
+            }
+            """;
+    }
+
+    /// <summary>
+    /// SYNTHETIC — runs shape: ["Upgraded membership to ", "Rat Boss!", "!"] (tier name ends with "!").
+    /// Mirrors the runs new-member fixture (<see cref="NewMemberChickenMcNugget"/>).
+    /// </summary>
+    public static string SyntheticUpgrade_RunsShape_RatBoss()
+    {
+        long ts = GetTimestampUsec(132);
+        return $$"""
+            {
+              "id": "UPGRADE_SYNTHETIC_RUNS_ID",
+              "timestampUsec": "{{ts}}",
+              "authorExternalChannelId": "UC_CHANNEL_ID_UPGRADE_RUNS",
+              "headerSubtext": { "runs": [
+                { "text": "Upgraded membership to " },
+                { "text": "Rat Boss!" },
+                { "text": "!" }
+              ]},
+              "authorName": { "simpleText": "UpgradeUserRuns" },
+              "authorPhoto": { "thumbnails": [{ "url": "https://yt4.ggpht.com/placeholder_upgrade_runs_s32.png" }] },
+              "authorBadges": [{
+                "liveChatAuthorBadgeRenderer": {
+                  "customThumbnail": { "thumbnails": [{ "url": "https://yt3.ggpht.com/placeholder_upgrade_runs_badge_s16.png" }] },
+                  "tooltip": "Member (1 month)",
+                  "accessibility": { "accessibilityData": { "label": "Member (1 month)" } }
+                }
+              }]
+            }
+            """;
+    }
+
     public static string NewMemberWithExclamationTier_RatBoss()
     {
         long ts = GetTimestampUsec(130); // Unique offset

--- a/YTLiveChat.Tests/TestData/MembershipTestData.cs
+++ b/YTLiveChat.Tests/TestData/MembershipTestData.cs
@@ -323,67 +323,52 @@ internal static class MembershipTestData
             }
             """;
     }
-    // ── Synthetic upgrade test data ─────────────────────────────────────────────
-    // NOTE: No real InnerTube capture for tier-upgrade events exists yet.
-    // These fixtures are synthesized from the user report in https://github.com/Agash/YTLiveChat/issues/42
-    // (tier name "Rat Boss!", observed headerSubtext "Upgraded membership to Rat Boss!!") and from
-    // the analogous shape of existing New-member fixtures.  Replace with real captures when available.
+    // ── Real upgrade event data ──────────────────────────────────────────────────
+    // Captured from a live stream (upgrade_events.json, 2026-04-15).
+    // Author @rembray upgraded to tier "Cardinal Archer". Badge shows "Member (1 year)".
+    // headerSubtext.runs shape: ["Upgraded membership to ", "Cardinal Archer", "!"]
 
     /// <summary>
-    /// SYNTHETIC — simpleText shape: "Upgraded membership to Rat Boss!!" (tier name ends with "!").
-    /// Mirrors the simpleText new-member fixture (<see cref="NewMemberWithExclamationTier_RatBoss"/>).
+    /// Real InnerTube capture of a membership tier-upgrade event.
+    /// Author @rembray upgraded to "Cardinal Archer"; badge tooltip "Member (1 year)".
+    /// headerSubtext uses the runs shape: ["Upgraded membership to ", "Cardinal Archer", "!"].
     /// </summary>
-    public static string SyntheticUpgrade_SimpleText_RatBoss()
-    {
-        long ts = GetTimestampUsec(131);
-        return $$"""
+    public static string RealUpgrade_Runs_CardinalArcher() => """
             {
-              "id": "UPGRADE_SYNTHETIC_SIMPLE_ID",
-              "timestampUsec": "{{ts}}",
-              "authorExternalChannelId": "UC_CHANNEL_ID_UPGRADE_SIMPLE",
-              "headerSubtext": { "simpleText": "Upgraded membership to Rat Boss!!" },
-              "authorName": { "simpleText": "UpgradeUserSimple" },
-              "authorPhoto": { "thumbnails": [{ "url": "https://yt4.ggpht.com/placeholder_upgrade_s32.png" }] },
-              "authorBadges": [{
-                "liveChatAuthorBadgeRenderer": {
-                  "customThumbnail": { "thumbnails": [{ "url": "https://yt3.ggpht.com/placeholder_upgrade_badge_s16.png" }] },
-                  "tooltip": "Member (1 month)",
-                  "accessibility": { "accessibilityData": { "label": "Member (1 month)" } }
+              "id": "ChwKGkNNU1ZtdGpJOEpNREZaaFlUQWdkdV9nc1F3",
+              "timestampUsec": "1776280547006206",
+              "authorExternalChannelId": "UCdtey2zoNQ9HVgdK9oEA_RA",
+              "headerSubtext": {
+                "runs": [
+                  { "text": "Upgraded membership to " },
+                  { "text": "Cardinal Archer" },
+                  { "text": "!" }
+                ]
+              },
+              "authorName": { "simpleText": "@rembray" },
+              "authorPhoto": {
+                "thumbnails": [
+                  { "url": "https://yt4.ggpht.com/mJB4A5YFOYgDsqZAZuUcpkS4tk2hcvkZebaeZFnmp9yDrYtgm81Yryi7yluiSzQFFWRNQFTkJO4=s32-c-k-c0x00ffffff-no-rj", "width": 32, "height": 32 },
+                  { "url": "https://yt4.ggpht.com/mJB4A5YFOYgDsqZAZuUcpkS4tk2hcvkZebaeZFnmp9yDrYtgm81Yryi7yluiSzQFFWRNQFTkJO4=s64-c-k-c0x00ffffff-no-rj", "width": 64, "height": 64 }
+                ]
+              },
+              "authorBadges": [
+                {
+                  "liveChatAuthorBadgeRenderer": {
+                    "customThumbnail": {
+                      "thumbnails": [
+                        { "url": "https://yt3.ggpht.com/tKIBMjzE8uZl9tG3YmpH23umrYpX8AAHKZTMy2pb11eVRC1nADLV6IngZL8FSuFE_knwO6j1Zw=s16-c-k", "width": 16, "height": 16 },
+                        { "url": "https://yt3.ggpht.com/tKIBMjzE8uZl9tG3YmpH23umrYpX8AAHKZTMy2pb11eVRC1nADLV6IngZL8FSuFE_knwO6j1Zw=s32-c-k", "width": 32, "height": 32 }
+                      ]
+                    },
+                    "tooltip": "Member (1 year)",
+                    "accessibility": { "accessibilityData": { "label": "Member (1 year)" } }
+                  }
                 }
-              }]
+              ],
+              "trackingParams": "CAUQ4P0GIhMI8KiF2cjwkwMV_MdJBx3nJxgC"
             }
             """;
-    }
-
-    /// <summary>
-    /// SYNTHETIC — runs shape: ["Upgraded membership to ", "Rat Boss!", "!"] (tier name ends with "!").
-    /// Mirrors the runs new-member fixture (<see cref="NewMemberChickenMcNugget"/>).
-    /// </summary>
-    public static string SyntheticUpgrade_RunsShape_RatBoss()
-    {
-        long ts = GetTimestampUsec(132);
-        return $$"""
-            {
-              "id": "UPGRADE_SYNTHETIC_RUNS_ID",
-              "timestampUsec": "{{ts}}",
-              "authorExternalChannelId": "UC_CHANNEL_ID_UPGRADE_RUNS",
-              "headerSubtext": { "runs": [
-                { "text": "Upgraded membership to " },
-                { "text": "Rat Boss!" },
-                { "text": "!" }
-              ]},
-              "authorName": { "simpleText": "UpgradeUserRuns" },
-              "authorPhoto": { "thumbnails": [{ "url": "https://yt4.ggpht.com/placeholder_upgrade_runs_s32.png" }] },
-              "authorBadges": [{
-                "liveChatAuthorBadgeRenderer": {
-                  "customThumbnail": { "thumbnails": [{ "url": "https://yt3.ggpht.com/placeholder_upgrade_runs_badge_s16.png" }] },
-                  "tooltip": "Member (1 month)",
-                  "accessibility": { "accessibilityData": { "label": "Member (1 month)" } }
-                }
-              }]
-            }
-            """;
-    }
 
     public static string NewMemberWithExclamationTier_RatBoss()
     {

--- a/YTLiveChat.Tools/YTLiveChat.Tools.csproj
+++ b/YTLiveChat.Tools/YTLiveChat.Tools.csproj
@@ -10,6 +10,6 @@
     <ProjectReference Include="..\YTLiveChat\YTLiveChat.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.6" />
   </ItemGroup>
 </Project>

--- a/YTLiveChat/Contracts/Models/MembershipDetails.cs
+++ b/YTLiveChat/Contracts/Models/MembershipDetails.cs
@@ -34,19 +34,10 @@ public enum MembershipEventType
 
     /// <summary>
     /// A user upgraded their existing membership to a higher tier.
-    /// Detected from <c>headerSubtext</c> starting with "Upgraded membership to".
-    /// <para>
-    /// <b>EXPERIMENTAL / UNVERIFIED:</b> This event type is based on a single user report
-    /// (Agash/YTLiveChat#42) and a synthesized payload. No raw InnerTube capture has been
-    /// confirmed yet. The shape (simpleText vs. runs, exact prefix wording) may differ from
-    /// what is implemented here. Treat <c>LevelName</c> with caution for this event type.
-    /// </para>
+    /// Detected from <c>headerSubtext</c> using the runs shape
+    /// <c>["Upgraded membership to ", "{TierName}", "!"]</c>.
+    /// <c>LevelName</c> carries the destination tier name.
     /// </summary>
-    [Obsolete(
-        "EXPERIMENTAL: MembershipEventType.Upgraded is unverified against a real InnerTube payload. "
-        + "The detection heuristic and tier-name extraction may be incorrect. "
-        + "See https://github.com/Agash/YTLiveChat/issues/42 for tracking."
-    )]
     Upgraded,
 }
 

--- a/YTLiveChat/Contracts/Models/MembershipDetails.cs
+++ b/YTLiveChat/Contracts/Models/MembershipDetails.cs
@@ -31,6 +31,23 @@ public enum MembershipEventType
     /// The author of the ChatItem is the recipient.
     /// </summary>
     GiftRedemption,
+
+    /// <summary>
+    /// A user upgraded their existing membership to a higher tier.
+    /// Detected from <c>headerSubtext</c> starting with "Upgraded membership to".
+    /// <para>
+    /// <b>EXPERIMENTAL / UNVERIFIED:</b> This event type is based on a single user report
+    /// (Agash/YTLiveChat#42) and a synthesized payload. No raw InnerTube capture has been
+    /// confirmed yet. The shape (simpleText vs. runs, exact prefix wording) may differ from
+    /// what is implemented here. Treat <c>LevelName</c> with caution for this event type.
+    /// </para>
+    /// </summary>
+    [Obsolete(
+        "EXPERIMENTAL: MembershipEventType.Upgraded is unverified against a real InnerTube payload. "
+        + "The detection heuristic and tier-name extraction may be incorrect. "
+        + "See https://github.com/Agash/YTLiveChat/issues/42 for tracking."
+    )]
+    Upgraded,
 }
 
 /// <summary>

--- a/YTLiveChat/Helpers/Parser.cs
+++ b/YTLiveChat/Helpers/Parser.cs
@@ -1067,6 +1067,39 @@ internal static partial class Parser
                     }
                 }
                 else if (
+                    membershipInfo.HeaderSubtext?.StartsWith(
+                        "Upgraded membership to",
+                        StringComparison.OrdinalIgnoreCase
+                    ) == true
+                )
+                {
+                    // EXPERIMENTAL: shape is based on a single user report and a synthesized payload.
+                    // See https://github.com/Agash/YTLiveChat/issues/42 for tracking.
+#pragma warning disable CS0618 // MembershipEventType.Upgraded is intentionally marked experimental
+                    membershipInfo.EventType = Contracts.Models.MembershipEventType.Upgraded;
+#pragma warning restore CS0618
+
+                    // Try runs first (e.g. ["Upgraded membership to ", "Rat Boss!", "!"])
+                    string? tierFromRuns = TryExtractTierNameFromHeaderSubtextRuns(
+                        membershipItem.HeaderSubtext?.Runs
+                    );
+                    if (!string.IsNullOrWhiteSpace(tierFromRuns))
+                    {
+                        membershipInfo.LevelName = tierFromRuns!;
+                    }
+                    else if (!string.IsNullOrEmpty(membershipInfo.HeaderSubtext))
+                    {
+                        // Regex fallback for simpleText shape: "Upgraded membership to {TierName}!"
+                        // The greedy .+ correctly captures tier names that themselves end with "!" (e.g. "Rat Boss!").
+                        Match upgradeMatch = UpgradedMemberLevelFromSubtextRegex()
+                            .Match(membershipInfo.HeaderSubtext);
+                        if (upgradeMatch.Success)
+                        {
+                            membershipInfo.LevelName = upgradeMatch.Groups[1].Value.Trim();
+                        }
+                    }
+                }
+                else if (
                     membershipInfo.HeaderPrimaryText?.IndexOf(
                         "member for",
                         StringComparison.OrdinalIgnoreCase
@@ -1816,6 +1849,10 @@ internal static partial class Parser
     [GeneratedRegex(@"^Welcome to (.+)!$", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
     private static partial Regex NewMemberLevelFromSubtextRegex();
 
+    // EXPERIMENTAL — see MembershipEventType.Upgraded and https://github.com/Agash/YTLiveChat/issues/42
+    [GeneratedRegex(@"^Upgraded membership to (.+)!$", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
+    private static partial Regex UpgradedMemberLevelFromSubtextRegex();
+
     // Regex to extract gifter name from redemption message like "GifterName gifted you..."
     [GeneratedRegex(@"^(.*?) gifted you", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
     private static partial Regex GiftRedemptionGifterRegex();
@@ -1974,6 +2011,14 @@ internal static partial class Parser
     );
 
     private static Regex NewMemberLevelFromSubtextRegex() => _newMemberLevelFromSubtextRegex;
+
+    // EXPERIMENTAL — see MembershipEventType.Upgraded and https://github.com/Agash/YTLiveChat/issues/42
+    private static readonly Regex _upgradedMemberLevelFromSubtextRegex = new(
+        @"^Upgraded membership to (.+)!$",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled
+    );
+
+    private static Regex UpgradedMemberLevelFromSubtextRegex() => _upgradedMemberLevelFromSubtextRegex;
 
     private static readonly Regex _giftRedemptionGifterRegex = new(
         @"^(.*?) gifted you",

--- a/YTLiveChat/Helpers/Parser.cs
+++ b/YTLiveChat/Helpers/Parser.cs
@@ -1073,11 +1073,7 @@ internal static partial class Parser
                     ) == true
                 )
                 {
-                    // EXPERIMENTAL: shape is based on a single user report and a synthesized payload.
-                    // See https://github.com/Agash/YTLiveChat/issues/42 for tracking.
-#pragma warning disable CS0618 // MembershipEventType.Upgraded is intentionally marked experimental
                     membershipInfo.EventType = Contracts.Models.MembershipEventType.Upgraded;
-#pragma warning restore CS0618
 
                     // Try runs first (e.g. ["Upgraded membership to ", "Rat Boss!", "!"])
                     string? tierFromRuns = TryExtractTierNameFromHeaderSubtextRuns(
@@ -1849,7 +1845,6 @@ internal static partial class Parser
     [GeneratedRegex(@"^Welcome to (.+)!$", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
     private static partial Regex NewMemberLevelFromSubtextRegex();
 
-    // EXPERIMENTAL — see MembershipEventType.Upgraded and https://github.com/Agash/YTLiveChat/issues/42
     [GeneratedRegex(@"^Upgraded membership to (.+)!$", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
     private static partial Regex UpgradedMemberLevelFromSubtextRegex();
 
@@ -2012,7 +2007,6 @@ internal static partial class Parser
 
     private static Regex NewMemberLevelFromSubtextRegex() => _newMemberLevelFromSubtextRegex;
 
-    // EXPERIMENTAL — see MembershipEventType.Upgraded and https://github.com/Agash/YTLiveChat/issues/42
     private static readonly Regex _upgradedMemberLevelFromSubtextRegex = new(
         @"^Upgraded membership to (.+)!$",
         RegexOptions.IgnoreCase | RegexOptions.Compiled

--- a/YTLiveChat/YTLiveChat.csproj
+++ b/YTLiveChat/YTLiveChat.csproj
@@ -29,8 +29,8 @@
     </AssemblyAttribute>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.6" />
     <PackageReference Include="MinVer" Version="7.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
@@ -39,8 +39,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Threading.Channels" Version="10.0.5" />
-    <PackageReference Include="System.Text.Json" Version="10.0.5" />
+    <PackageReference Include="System.Threading.Channels" Version="10.0.6" />
+    <PackageReference Include="System.Text.Json" Version="10.0.6" />
   </ItemGroup>
   <ItemGroup>
     <None Include="../LICENSE.txt" Pack="true" PackagePath="" />


### PR DESCRIPTION
Closes #42

- Adds `MembershipEventType.Upgraded` (marked `[Obsolete]` emits warning at every call site to signal experimental status, Experimental is unavailable in netstandard and I won't add a polyfill for something temporary)
- Parser detects tier-upgrade events when `headerSubtext` starts with `"Upgraded membership to"`, using the same runs-first + regex-fallback tier extraction already proven for `New` events